### PR TITLE
Default Separator, and some clean up

### DIFF
--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -41,7 +41,11 @@ export default FrostText.extend(SpreadMixin, PropTypeMixin, {
     this._super(...arguments)
     run.scheduleOnce('sync', this, function () {
       const fmt = this.get('format')
-      const _value = this.get('currentValue') || moment().format(fmt)
+      // passing null to moment returns Invalid Date
+      let currentValue = this.get('currentValue') || undefined
+
+      const _value = moment(currentValue).format(fmt)
+
       this.setProperties({
         value: _value,
         currentValue: _value
@@ -99,7 +103,7 @@ export default FrostText.extend(SpreadMixin, PropTypeMixin, {
     }
   },
   actions: {
-    _onSelect (date) {
+    _onSelect () {
       const attempt = this.$('input').val()
       const value = this.get('el').toString()
       const previousValue = this.get('previousValue')
@@ -110,7 +114,7 @@ export default FrostText.extend(SpreadMixin, PropTypeMixin, {
         const onSelect = this.get('onSelect')
 
         if (value !== previousValue) {
-          if (onSelect && !this.get('onSelectFired')) {
+          if (onSelect) {
             onSelect(value)
           }
           this.set('didError', null)
@@ -118,7 +122,7 @@ export default FrostText.extend(SpreadMixin, PropTypeMixin, {
       } else if (!this.get('didError')) {
         const onError = this.get('onError')
         const e = Error(this.get('GENERIC_ERROR'))
-        if (onError && !this.get('onErrorFired')) {
+        if (onError) {
           onError(e)
         }
         this.set('didError', true)

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -46,6 +46,7 @@ $hover-bg: #f6f9fc;
   }
 
   .separator {
+    transform: translateY(25%);
     color: $frost-color-grey-4;
     font-size: 40px;
   }

--- a/addon/templates/components/frost-range-picker.hbs
+++ b/addon/templates/components/frost-range-picker.hbs
@@ -13,7 +13,13 @@
       onError=(action 'onError')
     }}
   </div>
-  {{component separator}}
+  <div class='separator'>
+    {{#if separator}}
+      {{component separator}}
+    {{else}}
+      -
+    {{/if}}
+  </div>
   <div class='item end-date'>
     <div class='title'>
       {{endTitle}}

--- a/addon/templates/components/frost-range-picker.hbs
+++ b/addon/templates/components/frost-range-picker.hbs
@@ -5,6 +5,7 @@
       {{startTitle}}
     </div>
     {{frost-date-time-picker
+      hook=(concat hook '-start')
       currentValue=currentStart
       dateValidator=startValidator
       timeValidator=startValidator
@@ -18,6 +19,7 @@
       {{endTitle}}
     </div>
     {{frost-date-time-picker
+      hook=(concat hook '-end')
       currentValue=currentEnd
       dateValidator=endValidator
       timeValidator=endValidator

--- a/tests/dummy/app/components/my-separator.js
+++ b/tests/dummy/app/components/my-separator.js
@@ -1,7 +1,0 @@
-import {Component} from 'ember-frost-core'
-
-import layout from '../templates/components/my-separator'
-
-export default Component.extend({
-  layout
-})

--- a/tests/dummy/app/pods/range-picker/template.hbs
+++ b/tests/dummy/app/pods/range-picker/template.hbs
@@ -28,7 +28,6 @@
             startTitle='Custom Start'
             currentValue=value
             endTitle='Custom End'
-            separator=(component 'my-separator')
             validator=(action 'myCustomValidator')
           }}
         </div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -3,10 +3,7 @@
 
 .dummy-body {
   margin-left: 20px;
-  .my-separator {
-    font-size: 40px;
-    transform: translateY(25%);
-  }
+  
   .chip {
     display: inline-block;
     padding: 0 25px;

--- a/tests/dummy/app/templates/components/my-separator.hbs
+++ b/tests/dummy/app/templates/components/my-separator.hbs
@@ -1,2 +1,0 @@
-{{! Template for the my-separator component }}
--

--- a/tests/integration/components/frost-date-picker-test.js
+++ b/tests/integration/components/frost-date-picker-test.js
@@ -11,12 +11,14 @@ import {
   initialize as initializeHook
 } from 'ember-hook'
 
+import wait from 'ember-test-helpers/wait'
+
+import {afterEach, beforeEach, describe} from 'mocha'
+import sinon from 'sinon'
+
 const {
   moment
 } = window
-
-import { beforeEach } from 'mocha'
-import sinon from 'sinon'
 
 describeComponent(
   'frost-date-picker',
@@ -25,89 +27,133 @@ describeComponent(
     integration: true
   },
   function () {
+    let sandbox
     beforeEach(function () {
+      sandbox = sinon.sandbox.create()
       initializeHook()
     })
 
-    it('opens on click', function (done) {
-      this.render(hbs`
-      {{frost-date-picker
-        hook='my-picker'
-      }}`)
-      run.later(() => {
-        $hook('my-picker-input').click()
-        expect($('.pika-single.is-hidden'), 'Is visible').to.have.length(0)
-        done()
-      })
+    afterEach(function () {
+      sandbox.restore()
     })
-    it('sends actions on open', function (done) {
-      let onDrawCalled = sinon.spy()
-      let onOpenCalled = sinon.spy()
-      this.set('onDraw', onDrawCalled)
-      this.set('onOpen', onOpenCalled)
-      this.render(hbs`
-      {{frost-date-picker
-        hook='my-picker'
-        onDraw=onDraw
-        onOpen=onOpen
-      }}`)
-      run.later(() => {
-        $hook('my-picker-input').click()
+
+    describe('behaviour', function () {
+      it('opens on click', function (done) {
+        this.render(hbs`
+        {{frost-date-picker
+          hook='my-picker'
+        }}`)
         run.later(() => {
-          expect(onDrawCalled.callCount, 'onDraw called').to.equal(1)
-          expect(onOpenCalled.callCount, 'onOpen called').to.equal(1)
+          $hook('my-picker-input').click()
+          expect($('.pika-single.is-hidden'), 'Is visible').to.have.length(0)
           done()
         })
       })
-    })
-
-    it('sets the date when the value is set', function (done) {
-      const mValue = '2010-10-10'
-      this.set('mValue', mValue)
-      this.render(hbs`
+      it('sends actions on open', function (done) {
+        let onDrawCalled = sinon.spy()
+        let onOpenCalled = sinon.spy()
+        this.set('onDraw', onDrawCalled)
+        this.set('onOpen', onOpenCalled)
+        this.render(hbs`
         {{frost-date-picker
           hook='my-picker'
-          currentValue=mValue
+          onDraw=onDraw
+          onOpen=onOpen
         }}`)
-      run.later(() => {
-        const value = $hook('my-picker-input').val()
-        expect(value, 'currentValue').to.equal(mValue)
-        done()
-      })
-    })
-
-    it('fetches now when no date provided', function (done) {
-      const fmt = 'YYYY-MM-DD'
-      this.set('fmt', fmt)
-      this.render(hbs`
-        {{frost-date-picker
-          hook='my-picker'
-          currentValue=mValue
-          format=format
-        }}`)
-      run.later(() => {
-        const mValue = this.get('mValue')
-        expect(mValue, 'currentValue').to.equal(moment().format(fmt))
-        done()
-      })
-    })
-
-    it('closes on outside click', function (done) {
-      let onCloseCalled = sinon.spy()
-      this.set('onClose', onCloseCalled)
-      this.render(hbs`
-      {{frost-date-picker
-        hook='my-picker'
-        onClose=onClose
-      }}`)
-      run.later(() => {
-        $hook('my-picker-input').click()
         run.later(() => {
-          this.$().click()
-          expect(onCloseCalled.callCount, 'onClose called').to.equal(1)
-          expect($('.pika-single.is-hidden'), 'Is hidden').to.have.length(1)
+          $hook('my-picker-input').click()
+          run.later(() => {
+            expect(onDrawCalled.callCount, 'onDraw called').to.equal(1)
+            expect(onOpenCalled.callCount, 'onOpen called').to.equal(1)
+            done()
+          })
+        })
+      })
+
+      it('sets the date when the value is set', function (done) {
+        const mValue = '2010-10-10'
+        this.set('mValue', mValue)
+        this.render(hbs`
+          {{frost-date-picker
+            hook='my-picker'
+            currentValue=mValue
+          }}`)
+        run.later(() => {
+          const value = $hook('my-picker-input').val()
+          expect(value, 'currentValue').to.equal(mValue)
           done()
         })
+      })
+
+      it('fetches now when no date provided', function (done) {
+        const fmt = 'YYYY-MM-DD'
+        this.set('fmt', fmt)
+        this.render(hbs`
+          {{frost-date-picker
+            hook='my-picker'
+            currentValue=mValue
+            format=format
+          }}`)
+        run.later(() => {
+          const mValue = this.get('mValue')
+          expect(mValue, 'currentValue').to.equal(moment().format(fmt))
+          done()
+        })
+      })
+      it('applies provided format', function (done) {
+        const fmt = 'YYYY-MM-DD-[test]'
+        this.set('fmt', fmt)
+        this.render(hbs`
+          {{frost-date-picker
+            hook='my-picker'
+            currentValue=mValue
+            format=fmt
+          }}`)
+        run.later(() => {
+          const mValue = this.get('mValue')
+          expect(mValue, 'currentValue').to.equal(moment().format(fmt))
+          done()
+        })
+      })
+      it('closes on outside click', function (done) {
+        let onCloseCalled = sinon.spy()
+        this.set('onClose', onCloseCalled)
+        this.render(hbs`
+        {{frost-date-picker
+          hook='my-picker'
+          onClose=onClose
+        }}`)
+        run.later(() => {
+          $hook('my-picker-input').click()
+          run.later(() => {
+            this.$().click()
+            expect(onCloseCalled.callCount, 'onClose called').to.equal(1)
+            expect($('.pika-single.is-hidden'), 'Is hidden').to.have.length(1)
+            done()
+          })
+        })
+      })
+    })
+    describe('after render', function () {
+      beforeEach(function () {
+        this.setProperties({
+          myHook: 'myThing'
+        })
+
+        this.render(hbs`
+          {{frost-date-time-picker
+            hook=myHook
+          }}
+        `)
+
+        return wait()
+      })
+      it('should have an element', function () {
+        expect(this.$()).to.have.length(1)
+      })
+
+      it('should be accessible via the hook', function () {
+        expect($hook('myThing')).to.have.length(1)
       })
     })
   }

--- a/tests/integration/components/frost-date-time-picker-test.js
+++ b/tests/integration/components/frost-date-time-picker-test.js
@@ -42,7 +42,6 @@ describeComponent(
 
         return wait()
       })
-
       it('should have an element', function () {
         expect(this.$()).to.have.length(1)
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
- Added default separator
- Cleaner validation for date-picker
- Fix date-picker test