### PR TITLE
Allowed empty values in date picker

### DIFF
--- a/test-support/ember-frost-date-picker.js
+++ b/test-support/ember-frost-date-picker.js
@@ -1,0 +1,61 @@
+import {$hook} from 'ember-hook'
+
+// Helpers taken from ember-pickaday
+
+/**
+ * Open the specified date picker and get an interactor for it
+ * @param {String} hook - the hook for the date picker component
+ * @returns {Object} an object than can selectDate
+ */
+export function openDatepicker(hook) {
+  hook = hook || 'bunsenForm'
+
+  const hookName = `${hook}-input`
+  const $input = $hook(hookName)
+  $input.click()
+
+  return PikadayInteractor
+}
+
+const PikadayInteractor = {
+  selectorForMonthSelect: '.pika-lendar:visible .pika-select-month',
+  selectorForYearSelect: '.pika-lendar:visible .pika-select-year',
+  selectDate: function(date) {
+    var day = date.getDate()
+    var month = date.getMonth()
+    var year = date.getFullYear()
+    var selectEvent = 'ontouchend' in document ? 'touchend' : 'mousedown'
+
+    $(this.selectorForYearSelect).val(year)
+    triggerNativeEvent($(this.selectorForYearSelect)[0], 'change')
+    $(this.selectorForMonthSelect).val(month)
+    triggerNativeEvent($(this.selectorForMonthSelect)[0], 'change')
+
+    triggerNativeEvent($('td[data-day="' + day + '"] button:visible')[0], selectEvent)
+  },
+  selectedDay: function() {
+    return $('.pika-single td.is-selected button').html()
+  },
+  selectedMonth: function() {
+    return $(this.selectorForMonthSelect + ' option:selected').val()
+  },
+  selectedYear: function() {
+    return $(this.selectorForYearSelect + ' option:selected').val()
+  },
+  minimumYear: function() {
+    return $(this.selectorForYearSelect).children().first().val()
+  },
+  maximumYear: function() {
+    return $(this.selectorForYearSelect).children().last().val()
+  }
+}
+
+function triggerNativeEvent(element, eventName) {
+  if (document.createEvent) {
+    var event = document.createEvent('Events')
+    event.initEvent(eventName, true, false)
+    element.dispatchEvent(event)
+  } else {
+    element.fireEvent('on' + eventName)
+  }
+}

--- a/tests/dummy/app/pods/base/controller.js
+++ b/tests/dummy/app/pods/base/controller.js
@@ -12,9 +12,14 @@ export default Controller.extend({
   },
   myDate: '2010-10-10',
   myTime: '01:02:03',
+  newDate: undefined,
   actions: {
     onSelect (value) {
       this._notify('success', `DatePickerSelect: ${value}`)
+    },
+    onSelectFromEmpty (value) {
+      this._notify('success', `OriginallyEmptyDatePickerSelect: ${value}`)
+      this.set('newDate', value)
     },
     onError (e) {
       this._notify('error', 'DatePickerError: ' + e)

--- a/tests/dummy/app/pods/base/template.hbs
+++ b/tests/dummy/app/pods/base/template.hbs
@@ -30,11 +30,21 @@
             onSelect=(action 'onSelect')
             onError=(action 'onError')
           }}
+          <h3>Originally Empty Date</h3>
+          {{frost-date-picker
+            hook='empty-date-picker'
+            onSelect=(action 'onSelectFromEmpty')
+            onOpen=(action 'onOpen')
+            onClose=(action 'onClose')
+            onDraw=(action 'onDraw')
+            onError=(action 'onError')
+          }}
         </div>
         <div class='item'>
           <h3>Current Values</h3>
-          Date: {{myDate}}
-          Time: {{myTime}}
+          <li>Date: {{myDate}}</li>
+          <li>Time: {{myTime}}</li>
+          <li>Originally Empty Date: {{newDate}}</li>
         </div>
         <!-- END-SNIPPET -->
       </div>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [x] #major# - incompatible API change

This is kinda a quick and dirty fix to enable this component to be used in a bunsen renderer, which I would really love to happen soon.

I marked it as major in case anyone is relying on the old default setting functionality. 

# CHANGELOG

* The `frost-date-picker` component now defaults to empty instead of the current date.
