### PR TITLE
override z-index on clockpicker-popover to 9999 to match the date picker

### DIFF
--- a/addon/styles/_clockpicker.scss
+++ b/addon/styles/_clockpicker.scss
@@ -1,0 +1,5 @@
+.popover {
+  &.clockpicker-popover {
+    z-index: 9999;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -6,4 +6,5 @@
 @import './frost-date-time-picker';
 @import './frost-range-picker';
 @import './frost-time-picker';
+@import './clockpicker';
 @import './pikaday';


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**Added** clockpicker styles to override z-index on clockpicker-popover to 9999 (same as the date picker) as the pulled in value (1010) is below that of ember-frost-modal (8000).
