### PR TITLE
Update to use lint from ember-test-utils

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,12 @@
+
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/package.json
+++ b/package.json
@@ -9,13 +9,10 @@
   },
   "scripts": {
     "build": "ember build",
+    "lint": "lint-all-the-things",
     "publish": ".scripts/deploy.sh",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "eslint": "eslint *.js addon app blueprints config tests",
-    "md-lint": "remark *.md",
-    "sass-lint": "sass-lint -q -v",
-    "start": "ember serve"
+    "start": "ember serve",
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-date-picker.git",
   "engines": {
@@ -62,17 +59,12 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.2",
-    "ember-test-utils": "^1.6.1",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.4.0",
-    "eslint-config-frost-standard": "^5.3.2",
     "estraverse-fb": "^1.3.1",
     "liquid-fire": "0.27.0",
     "loader.js": "^4.0.0",
     "pikaday": "^1.5.1",
-    "remark-cli": "^2.0.0",
-    "remark-lint": "^5.1.0",
-    "sass-lint": "^1.9.1",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0"
   },

--- a/test-support/ember-frost-date-picker.js
+++ b/test-support/ember-frost-date-picker.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import {$hook} from 'ember-hook'
 
 // Helpers taken from ember-pickaday
@@ -7,7 +9,7 @@ import {$hook} from 'ember-hook'
  * @param {String} hook - the hook for the date picker component
  * @returns {Object} an object than can selectDate
  */
-export function openDatepicker(hook) {
+export function openDatepicker (hook) {
   hook = hook || 'bunsenForm'
 
   const hookName = `${hook}-input`
@@ -20,7 +22,7 @@ export function openDatepicker(hook) {
 const PikadayInteractor = {
   selectorForMonthSelect: '.pika-lendar:visible .pika-select-month',
   selectorForYearSelect: '.pika-lendar:visible .pika-select-year',
-  selectDate: function(date) {
+  selectDate: function (date) {
     var day = date.getDate()
     var month = date.getMonth()
     var year = date.getFullYear()
@@ -33,24 +35,24 @@ const PikadayInteractor = {
 
     triggerNativeEvent($('td[data-day="' + day + '"] button:visible')[0], selectEvent)
   },
-  selectedDay: function() {
+  selectedDay: function () {
     return $('.pika-single td.is-selected button').html()
   },
-  selectedMonth: function() {
+  selectedMonth: function () {
     return $(this.selectorForMonthSelect + ' option:selected').val()
   },
-  selectedYear: function() {
+  selectedYear: function () {
     return $(this.selectorForYearSelect + ' option:selected').val()
   },
-  minimumYear: function() {
+  minimumYear: function () {
     return $(this.selectorForYearSelect).children().first().val()
   },
-  maximumYear: function() {
+  maximumYear: function () {
     return $(this.selectorForYearSelect).children().last().val()
   }
 }
 
-function triggerNativeEvent(element, eventName) {
+function triggerNativeEvent (element, eventName) {
   if (document.createEvent) {
     var event = document.createEvent('Events')
     event.initEvent(eventName, true, false)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-date-picker/issues/38

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-date-picker/39)
<!-- Reviewable:end -->
