### PR TITLE
add support for engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,25 @@ module.exports = {
     /* eslint-enable no-unused-expressions */
   },
 
-  included: function (app) {
-    this._super.included(app)
-    app.import(`${app.bowerDirectory}/clockpicker-seconds/dist/jquery-clockpicker.min.js`)
+  _findHost: function () {
+    var current = this
+    var app
+
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    do {
+      app = current.app || app
+    } while (current.parent.parent && (current = current.parent))
+    return app
+  },
+
+  included: function () {
+    var app = this._findHost()
+
+    if (!app.bowerDirectory) {
+      app.import('bower_components/clockpicker-seconds/dist/jquery-clockpicker.min.js')
+    } else {
+      app.import(`${app.bowerDirectory}/clockpicker-seconds/dist/jquery-clockpicker.min.js`)
+    }
   }
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* for the bower directory search to work in an engine env, **added** code to climb the tree to find the real parent `app`
