### PR TITLE
Fixed pikaday memory leak on `_onKeyChange`

### DIFF
--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -89,6 +89,8 @@ export default Component.extend(EventsProxyMixin, {
   },
 
   willDestroyElement () {
+    // TODO: This will not be necessary once https://github.com/dbushell/Pikaday/issues/630 is fixed - @dafortin 2017.06.08
+    document.removeEventListener('keydown', this.get('pikadayElement')._onKeyChange)
     this.get('pikadayElement').destroy()
     this._super(...arguments)
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** `pikaday` memory leak on `_onKeyChange`