### PR TITLE
Add in ability to format date and time strings

### DIFF
--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -49,18 +49,10 @@ export default Component.extend(EventsProxyMixin, {
 
   @readOnly
   @computed('value')
-  _validatedValue (value) {
-    if (value) {
-      return moment(value, this.get('format'))
-    }
-    return false
-  },
-
-  @readOnly
-  @computed('_validatedValue')
-  _value (_validatedValue) {
-    if (_validatedValue && _validatedValue.isValid()) {
-      return _validatedValue.format(this.get('format'))
+  _value (value) {
+    const validatedValue = moment(value, this.get('format'))
+    if (validatedValue.isValid()) {
+      return validatedValue.format(this.get('format'))
     }
     return 'Invalid'
   },
@@ -80,7 +72,6 @@ export default Component.extend(EventsProxyMixin, {
   // Named to match the event from Pikaday
   _onSelect () {
     const value = this.$('input').val()
-    this.$('input').val(this.get('_value'))
     this.onChange(value)
   },
 

--- a/addon/components/frost-time-picker.js
+++ b/addon/components/frost-time-picker.js
@@ -3,9 +3,14 @@
  */
 
 import Ember from 'ember'
+import computed, {readOnly} from 'ember-computed-decorators'
 const {run} = Ember
 import {Text, utils} from 'ember-frost-core'
+import {Format} from 'ember-frost-date-picker'
 import {PropTypes} from 'ember-prop-types'
+import moment from 'moment'
+
+const DEFAULT_TIME_FORMAT = Format.time
 
 export default Text.extend({
 
@@ -34,19 +39,57 @@ export default Text.extend({
       // Options for https://weareoutman.github.io/clockpicker/
       autoclose: false,
       donetext: 'Set',
-      format: 'HH:mm:ss',
+      format: DEFAULT_TIME_FORMAT,
       placement: 'right'
     }
   },
 
   // == Computed Properties ===================================================
 
+  @readOnly
+  @computed('value')
+  _validatedValue (value) {
+    if (value) {
+      return moment(value, this.get('format'))
+    }
+    return false
+  },
+
+  @readOnly
+  @computed('_validatedValue')
+  _value (_validatedValue) {
+    if (_validatedValue && _validatedValue.isValid()) {
+      return _validatedValue.format(this.get('format'))
+    }
+    return 'Invalid'
+  },
+
   // == Functions =============================================================
+
+  _clockpickerFormat (value) {
+    return moment(value, this.get('format')).format(DEFAULT_TIME_FORMAT)
+  },
+
+  _displayFormat (value) {
+    return moment(value, DEFAULT_TIME_FORMAT).format(this.get('format'))
+  },
 
   // Named to match the event from https://weareoutman.github.io/clockpicker/
   _afterDone () {
     const value = this.$('input').val()
-    this.onChange(value)
+    this.$('input').val(this.get('_value'))
+    this.onChange(this._displayFormat(value))
+  },
+
+  // Named to match the event from https://weareoutman.github.io/clockpicker/
+  _beforeShow () {
+    let value = this.$('input').val()
+    this.$('input').val(this._clockpickerFormat(value))
+  },
+
+  // Named to match the event from https://weareoutman.github.io/clockpicker/
+  _init () {
+    this.$('input').val(this.get('_value'))
   },
 
   // == DOM Events ============================================================
@@ -70,7 +113,9 @@ export default Text.extend({
         donetext: this.get('donetext'),
         format: this.get('format'),
         placement: this.get('placement'),
-        afterDone: run.bind(this, this._afterDone)
+        afterDone: run.bind(this, this._afterDone),
+        beforeShow: run.bind(this, this._beforeShow),
+        init: run.bind(this, this._init)
       })
     })
   },

--- a/addon/components/frost-time-picker.js
+++ b/addon/components/frost-time-picker.js
@@ -48,25 +48,17 @@ export default Text.extend({
 
   @readOnly
   @computed('value')
-  _validatedValue (value) {
-    if (value) {
-      return moment(value, this.get('format'))
-    }
-    return false
-  },
-
-  @readOnly
-  @computed('_validatedValue')
-  _value (_validatedValue) {
-    if (_validatedValue && _validatedValue.isValid()) {
-      return _validatedValue.format(this.get('format'))
+  _value (value) {
+    const momentValue = moment(value, this.get('format'))
+    if (momentValue.isValid()) {
+      return momentValue.format(this.get('format'))
     }
     return 'Invalid'
   },
 
   // == Functions =============================================================
 
-  _clockpickerFormat (value) {
+  _clockPickerFormat (value) {
     return moment(value, this.get('format')).format(DEFAULT_TIME_FORMAT)
   },
 
@@ -77,14 +69,13 @@ export default Text.extend({
   // Named to match the event from https://weareoutman.github.io/clockpicker/
   _afterDone () {
     const value = this.$('input').val()
-    this.$('input').val(this.get('_value'))
     this.onChange(this._displayFormat(value))
   },
 
   // Named to match the event from https://weareoutman.github.io/clockpicker/
   _beforeShow () {
     let value = this.$('input').val()
-    this.$('input').val(this._clockpickerFormat(value))
+    this.$('input').val(this._clockPickerFormat(value)) // Clock picker only works with this format
   },
 
   // Named to match the event from https://weareoutman.github.io/clockpicker/

--- a/addon/templates/components/frost-date-picker.hbs
+++ b/addon/templates/components/frost-date-picker.hbs
@@ -12,7 +12,7 @@
   tabindex=tabindex
   title=title
   type=type
-  value=(readonly value)
+  value=(readonly _value)
 
   onClick=_eventProxy.click
   onContextMenu=_eventProxy.contextMenu

--- a/addon/templates/components/frost-date-time-picker.hbs
+++ b/addon/templates/components/frost-date-time-picker.hbs
@@ -3,7 +3,7 @@
 {{#if date}}
   {{component date
     hook=(concat hookPrefix '-date-picker')
-    class=(if (or _valueInvalid _dateValueInvalid) 'error')
+    class=(if (or _valueInvalid _selectedDateValueInvalid) 'error')
     value=(readonly _dateValue)
     onChange=(action '_onDateChange')
     format=(readonly dateFormat)
@@ -11,7 +11,7 @@
 {{else}}
   {{frost-date-picker
     hook=(concat hookPrefix '-date-picker')
-    class=(if (or _valueInvalid _dateValueInvalid) 'error')
+    class=(if (or _valueInvalid _selectedDateValueInvalid) 'error')
     value=(readonly _dateValue)
     onChange=(action '_onDateChange')
     format=(readonly dateFormat)
@@ -21,7 +21,7 @@
 {{#if time}}
   {{component time
     hook=(concat hookPrefix '-time-picker')
-    class=(if (or _valueInvalid _timeValueInvalid) 'error')
+    class=(if (or _valueInvalid _selectedTimeValueInvalid) 'error')
     value=(readonly _timeValue)
     onChange=(action '_onTimeChange')
     format=(readonly timeFormat)
@@ -29,7 +29,7 @@
 {{else}}
   {{frost-time-picker
     hook=(concat hookPrefix '-time-picker')
-    class=(if (or _valueInvalid _timeValueInvalid) 'error')
+    class=(if (or _valueInvalid _selectedTimeValueInvalid) 'error')
     value=(readonly _timeValue)
     onChange=(action '_onTimeChange')
     format=(readonly timeFormat)

--- a/addon/templates/components/frost-date-time-picker.hbs
+++ b/addon/templates/components/frost-date-time-picker.hbs
@@ -6,6 +6,7 @@
     class=(if (or _valueInvalid _dateValueInvalid) 'error')
     value=(readonly _dateValue)
     onChange=(action '_onDateChange')
+    format=(readonly dateFormat)
   }}
 {{else}}
   {{frost-date-picker
@@ -13,6 +14,7 @@
     class=(if (or _valueInvalid _dateValueInvalid) 'error')
     value=(readonly _dateValue)
     onChange=(action '_onDateChange')
+    format=(readonly dateFormat)
   }}
 {{/if}}
 
@@ -22,6 +24,7 @@
     class=(if (or _valueInvalid _timeValueInvalid) 'error')
     value=(readonly _timeValue)
     onChange=(action '_onTimeChange')
+    format=(readonly timeFormat)
   }}
 {{else}}
   {{frost-time-picker
@@ -29,5 +32,6 @@
     class=(if (or _valueInvalid _timeValueInvalid) 'error')
     value=(readonly _timeValue)
     onChange=(action '_onTimeChange')
+    format=(readonly timeFormat)
   }}
 {{/if}}

--- a/test-support/ember-frost-time-picker.js
+++ b/test-support/ember-frost-time-picker.js
@@ -60,10 +60,12 @@ const ClockpickerInteractor = {
     // Event options
     const options = {bubbles: false, clientX: xMiddle, clientY: yMiddle}
 
+    /* eslint-disable */
     element.dispatchEvent(new MouseEvent('mouseover', options))
     element.dispatchEvent(new MouseEvent('mousedown', options))
     element.dispatchEvent(new MouseEvent('mouseup', options))
     element.dispatchEvent(new MouseEvent('click', options))
+    /* eslint-enable */
     setTimeout(function () { }, 150)
   }
 }

--- a/test-support/ember-frost-time-picker.js
+++ b/test-support/ember-frost-time-picker.js
@@ -1,0 +1,69 @@
+/* global $ */
+
+import {$hook} from 'ember-hook'
+
+/*
+ * NOTE the interactor will only work when passed in seconds
+ * and minutes that are multiples of 5
+ */
+
+/**
+ * Open the specified time picker and get an interactor for it
+ * @param {String} hook - the hook for the time picker component
+ * @returns {Object} an object than can selectTime
+ */
+export function openTimepicker (hook) {
+  hook = hook || 'bunsenForm'
+
+  const hookName = `${hook}-input`
+  const $input = $hook(hookName)
+  $input.click()
+
+  return ClockpickerInteractor
+}
+
+const ClockpickerInteractor = {
+  getSelectedTime: function () {
+    return {
+      hour: $('.clockpicker-popover:visible .clockpicker-span-hours').text(),
+      minute: $('.clockpicker-popover:visible .clockpicker-span-minutes').text(),
+      second: $('.clockpicker-popover:visible .clockpicker-span-seconds').text()
+    }
+  },
+
+  selectTime: function (hour, minute, second) {
+    let selectorForHour = `.clockpicker-popover:visible .clockpicker-hours .clockpicker-tick:contains("${hour}")`
+    let selectorForMinute = `.clockpicker-popover:visible .clockpicker-minutes .clockpicker-tick:contains("${minute}")`
+    let selectorForSecond = `.clockpicker-popover:visible .clockpicker-seconds .clockpicker-tick:contains("${second}")`
+
+    this.simulateClick($(selectorForHour)[0])
+    this.simulateClick($(selectorForMinute)[0])
+    this.simulateClick($(selectorForSecond)[0])
+  },
+
+  /*
+   * TODO not working currently. Does not work when the datepicker is not in view
+   * (need to scroll to see it). Pulled inspiration from:
+   * https://stackoverflow.com/questions/26126663/jquery-click-on-a-div-button-wont-fire
+   */
+  simulateClick: function (element) {
+    let rect = element.getBoundingClientRect()
+
+    // Absolute position
+    const top = rect.top
+    const left = rect.left
+
+    // Coordinates of center of element
+    const yMiddle = top + (rect.height / 2)
+    const xMiddle = left + (rect.width / 2)
+
+    // Event options
+    const options = {bubbles: false, clientX: xMiddle, clientY: yMiddle}
+
+    element.dispatchEvent(new MouseEvent('mouseover', options))
+    element.dispatchEvent(new MouseEvent('mousedown', options))
+    element.dispatchEvent(new MouseEvent('mouseup', options))
+    element.dispatchEvent(new MouseEvent('click', options))
+    setTimeout(function () { }, 150)
+  }
+}

--- a/tests/integration/components/frost-date-picker-test.js
+++ b/tests/integration/components/frost-date-picker-test.js
@@ -209,7 +209,7 @@ describe(test.label, function () {
     beforeEach(function () {
       changeStub = sandbox.stub()
       this.setProperties({
-        dateValue,
+        dateValue: '2017-06-19',
         myHook: 'myHook',
         onChange: changeStub
       })
@@ -224,17 +224,111 @@ describe(test.label, function () {
 
       return wait().then(() => {
         const interactor = openDatepicker('myHook')
-        interactor.selectDate(new Date(2017, 0, 24))
+        interactor.selectDate(new Date(2017, 5, 24))
         closePikaday(this)
       })
     })
 
     it('should call onChange with the updated value', function () {
-      expect(changeStub).to.have.been.calledWith('2017-01-24')
+      expect(changeStub).to.have.been.calledWith('2017-06-24')
     })
 
-    it('should display the updated value', function () {
-      expect($hook('myHook-input')).to.have.value('2017-01-24')
+    it('input text should be unchanged', function () {
+      expect($hook('myHook-input')).to.have.value('2017-06-19')
+    })
+  })
+
+  describe('uses specified format', function () {
+    let changeStub
+
+    beforeEach(function () {
+      changeStub = function (val) {
+        this.setProperties({
+          dateValue: val
+        })
+      }
+      this.setProperties({
+        dateValue: '1995/02/27',
+        myHook: 'myHook',
+        dateFormat: 'YYYY/MM/DD',
+        onChange: changeStub
+      })
+
+      this.render(hbs`
+        {{frost-date-picker
+          hook=myHook
+          onChange=onChange
+          value=dateValue
+          format=dateFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should display the formatted value', function () {
+      expect($hook('myHook-input')).to.have.value('1995/02/27')
+    })
+  })
+
+  describe('value does not match specified format', function () {
+    beforeEach(function () {
+      this.setProperties({
+        dateValue,
+        myHook: 'myHook',
+        dateFormat: 'abcdefgh',
+        onChange: function () {}
+      })
+
+      this.render(hbs`
+        {{frost-date-picker
+          hook=myHook
+          onChange=onChange
+          value=dateValue
+          format=dateFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should display the invalid value', function () {
+      expect($hook('myHook-input')).to.have.value('Invalid')
+    })
+  })
+
+  describe('updates using specified format', function () {
+    beforeEach(function () {
+      let changeStub = (val) => {
+        this.setProperties({
+          dateValue: val
+        })
+      }
+      this.setProperties({
+        dateValue: '2017/01/01',
+        myHook: 'myHook',
+        dateFormat: 'YYYY/MM/DD',
+        onChange: changeStub
+      })
+
+      this.render(hbs`
+        {{frost-date-picker
+          hook=myHook
+          onChange=onChange
+          value=dateValue
+          format=dateFormat
+        }}
+      `)
+
+      return wait().then(() => {
+        const interactor = openDatepicker('myHook')
+        interactor.selectDate(new Date(2017, 0, 24))
+        closePikaday(this)
+      })
+    })
+
+    it('should display the updated, formatted value', function () {
+      expect($hook('myHook-input')).to.have.value('2017/01/24')
     })
   })
 })

--- a/tests/integration/components/frost-date-picker-test.js
+++ b/tests/integration/components/frost-date-picker-test.js
@@ -233,8 +233,8 @@ describe(test.label, function () {
       expect(changeStub).to.have.been.calledWith('2017-06-24')
     })
 
-    it('input text should be unchanged', function () {
-      expect($hook('myHook-input')).to.have.value('2017-06-19')
+    it('input text should be changed', function () {
+      expect($hook('myHook-input')).to.have.value('2017-06-24')
     })
   })
 

--- a/tests/integration/components/frost-date-time-picker-test.js
+++ b/tests/integration/components/frost-date-time-picker-test.js
@@ -13,6 +13,8 @@ import {afterEach, beforeEach, describe, it} from 'mocha'
 import moment from 'moment'
 import sinon from 'sinon'
 
+import {openDatepicker} from 'dummy/tests/ember-frost-date-picker'
+
 const test = integration('frost-date-time-picker')
 describe(test.label, function () {
   test.setup()
@@ -148,6 +150,92 @@ describe(test.label, function () {
 
     it('should error class on frost-date-picker', function () {
       expect($hook('myHook-time-picker')).to.have.class('error')
+    })
+  })
+
+  describe('dateFormat is set', function () {
+    const dateTimeValue = moment('2017 01 01 01 23 45', 'YYYY MM DD hh mm ss').format(Format.dateTime)
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        dateTimeValue: dateTimeValue,
+        onChange: function () {},
+        dateFormat: 'MM/DD/YY'
+      })
+
+      this.render(hbs`
+        {{frost-date-time-picker
+          hook=myHook
+          onChange=onChange
+          value=dateTimeValue
+          dateFormat=dateFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('date picker should format selected date with provided date format', function () {
+      expect($hook('myHook-date-picker-input').val()).to.equal('01/01/17')
+    })
+  })
+
+  describe('timeFormat is set', function () {
+    const dateTimeValue = moment('2017 01 01 01 23 45', 'YYYY MM DD hh mm ss').format(Format.dateTime)
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        dateTimeValue: dateTimeValue,
+        onChange: function () {},
+        timeFormat: 'hh-mm-ss'
+      })
+
+      this.render(hbs`
+        {{frost-date-time-picker
+          hook=myHook
+          onChange=onChange
+          value=dateTimeValue
+          timeFormat=timeFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('time picker should format selected time with provided time format', function () {
+      expect($hook('myHook-time-picker-input').val()).to.equal('01-23-45')
+    })
+  })
+
+  describe('dateTimeFormat is set', function () {
+    const dateTimeValue = moment('2017 01 01 01 23 45', 'YYYY MM DD hh mm ss').format(Format.dateTime)
+    let changeStub
+    beforeEach(function () {
+      changeStub = sandbox.stub()
+      this.setProperties({
+        myHook: 'myHook',
+        dateTimeValue: dateTimeValue,
+        onChange: changeStub,
+        dateTimeFormat: 'MM/DD/YY :: hh-mm-ss'
+      })
+      this.render(hbs`
+        {{frost-date-time-picker
+          hook=myHook
+          onChange=onChange
+          value=dateTimeValue
+          dateTimeFormat=dateTimeFormat
+        }}
+      `)
+
+      return wait().then(() => {
+        const interactor = openDatepicker('myHook-date-picker')
+        interactor.selectDate(new Date(2017, 0, 24))
+        this.$().click() // Click outside date picker to close it
+      })
+    })
+
+    it('selected time passed to onChange should use provided dateTimeFormat', function () {
+      expect(changeStub).to.have.been.calledWith('01/24/17 :: 01-23-45')
     })
   })
 })

--- a/tests/integration/components/frost-time-picker-test.js
+++ b/tests/integration/components/frost-time-picker-test.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 /**
  * Integration test for the frost-time-picker component
  */
@@ -11,6 +13,8 @@ import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import moment from 'moment'
 import sinon from 'sinon'
+
+import {openTimepicker} from 'dummy/tests/ember-frost-time-picker'
 
 const test = integration('frost-time-picker')
 describe(test.label, function () {
@@ -49,6 +53,222 @@ describe(test.label, function () {
 
     it('should be accessible via the hook', function () {
       expect($hook('myHook-input')).to.have.value(timeValue)
+    })
+  })
+
+  describe('format is set', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue: '01-23-45',
+        onChange: function () {},
+        timeFormat: 'hh-mm-ss'
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format=timeFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('time value format matches custom format', function () {
+      expect($hook('myHook-input').val()).to.equal('01-23-45')
+    })
+  })
+
+  describe('format is invalid', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue,
+        onChange: function () {},
+        timeFormat: 'yyyyyy'
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format=timeFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('displays invalid string', function () {
+      expect($hook('myHook-input').val()).to.equal('Invalid')
+    })
+  })
+
+  describe('value does not match set format', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue: '1995-02-27',
+        onChange: function () {},
+        timeFormat: 'HH:mm:ss'
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format=timeFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('displays invalid string', function () {
+      expect($hook('myHook-input').val()).to.equal('Invalid')
+    })
+  })
+
+  describe('format string is empty', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue,
+        onChange: function () {},
+        timeFormat: ''
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format=timeFormat
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('displays invalid string', function () {
+      expect($hook('myHook-input').val()).to.equal('Invalid')
+    })
+  })
+
+  describe('open clockpicker', function () {
+    let selectedTime
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue: '01:23:45',
+        onChange: (val) => {
+          this.setProperties({
+            timeValue: val
+          })
+        }
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format='HH-mm-ss'
+        }}
+      `)
+
+      return wait().then(() => {
+        const interactor = openTimepicker('myHook')
+        selectedTime = interactor.getSelectedTime()
+        this.$().click() // click outside to close clock picker
+      })
+    })
+
+    it('clockpicker opens to last selected time', function () {
+      expect(selectedTime.hour).to.equal('01')
+      expect(selectedTime.minute).to.equal('23')
+      expect(selectedTime.second).to.equal('45')
+    })
+  })
+
+  describe('select new time', function () {
+    let changeStub
+    beforeEach(function () {
+      changeStub = sandbox.stub()
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue: '01-23-45',
+        timeFormat: 'HH-mm-ss',
+        onChange: changeStub
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format=timeFormat
+        }}
+      `)
+
+      return wait().then(() => {
+        /*
+         * TODO replace with commented out selection code once fixed
+         */
+        $hook('myHook-input').val('05:10:15')
+        openTimepicker('myHook')
+        this.$().click() // click outside to close clock picker
+
+        // const interactor = openTimepicker('myHook')
+        // interactor.selectTime('12', '05', '10')
+        // this.$().click() // click outside to close clock picker
+      })
+    })
+
+    it('onChange method called with formatted time string', function () {
+      expect(changeStub).to.have.been.calledWith('05-10-15')
+    })
+  })
+
+  describe.skip('select new time and update value', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue,
+        timeFormat: 'HH-mm-ss',
+        onChange: (val) => {
+          this.setProperties({
+            timeValue: val
+          })
+        }
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=timeValue
+          format=timeFormat
+        }}
+      `)
+
+      return wait().then(() => {
+        /*
+         * TODO get popup selection working
+         */
+        const interactor = openTimepicker('myHook')
+        interactor.selectTime(5, 10, 15)
+        this.$().click() // click outside to close clock picker
+      })
+    })
+
+    it('input text is updated', function () {
+      expect($hook('myHook-input').val()).to.equal('05-10-15')
     })
   })
 })

--- a/tests/integration/components/frost-time-picker-test.js
+++ b/tests/integration/components/frost-time-picker-test.js
@@ -1,5 +1,3 @@
-/* global $ */
-
 /**
  * Integration test for the frost-time-picker component
  */


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [X] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Need to (re)add in this functionality to not break `ember-frost-bunsen`

# CHANGELOG
 * **Added** ability to format date and time strings
