### PR TITLE
Use date prop type for date-time-picker

### DIFF
--- a/addon/components/frost-date-time-picker.js
+++ b/addon/components/frost-date-time-picker.js
@@ -29,8 +29,7 @@ export default Component.extend({
     date: PropTypes.EmberComponent,
     dateFormat: PropTypes.string,
     dateTimeFormat: PropTypes.string,
-    // FIXME: we should implement a date type in prop types - @dafortin 2017.06.24
-    minDate: PropTypes.instanceOf(Date),
+    minDate: PropTypes.date,
     time: PropTypes.EmberComponent,
     timeFormat: PropTypes.string,
     value: PropTypes.string.isRequired,


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Use** date prop type for date-time-picker