### PR TITLE
Fixed null and empty string date-picker values

### DIFF
--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -51,7 +51,7 @@ export default Component.extend(EventsProxyMixin, {
   @computed('value')
   _value (value) {
     const emptyValues = new Set(['', undefined, null])
-    if (value in emptyValues) {
+    if (emptyValues.has(value)) {
       // UX requires us to support date pickers that do not yet have a date picked.
       return undefined  // explicitly allow empty values for un-picked date values.
     }

--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -50,7 +50,8 @@ export default Component.extend(EventsProxyMixin, {
   @readOnly
   @computed('value')
   _value (value) {
-    if (!value) {
+    const emptyValues = new Set(['', undefined, null])
+    if (value in emptyValues) {
       // UX requires us to support date pickers that do not yet have a date picked.
       return undefined  // explicitly allow empty values for un-picked date values.
     }

--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -50,7 +50,7 @@ export default Component.extend(EventsProxyMixin, {
   @readOnly
   @computed('value')
   _value (value) {
-    if (value === undefined) {
+    if (!value) {
       // UX requires us to support date pickers that do not yet have a date picked.
       return undefined  // explicitly allow empty values for un-picked date values.
     }

--- a/addon/components/frost-date-picker.js
+++ b/addon/components/frost-date-picker.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {run, typeOf} = Ember
+const {isEmpty, run, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component, EventsProxyMixin} from 'ember-frost-core'
 import {Format} from 'ember-frost-date-picker'
@@ -27,7 +27,10 @@ export default Component.extend(EventsProxyMixin, {
 
     // Options
     isIconVisible: PropTypes.bool,
-    value: PropTypes.string,  // No longer required, because UX requires us to be able to present empty selections
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.null
+    ]),  // No longer required, because UX requires us to be able to present empty selections
     format: PropTypes.string,
 
     // Events
@@ -50,8 +53,7 @@ export default Component.extend(EventsProxyMixin, {
   @readOnly
   @computed('value')
   _value (value) {
-    const emptyValues = new Set(['', undefined, null])
-    if (emptyValues.has(value)) {
+    if (isEmpty(value)) {
       // UX requires us to support date pickers that do not yet have a date picked.
       return undefined  // explicitly allow empty values for un-picked date values.
     }

--- a/tests/integration/components/frost-date-picker-test.js
+++ b/tests/integration/components/frost-date-picker-test.js
@@ -78,7 +78,6 @@ describe(test.label, function () {
     // wants to have an optional date field.
     beforeEach(function () {
       this.setProperties({
-        dateValue: undefined,
         myHook: 'myHook',
         onChange: function () {}
       })
@@ -87,7 +86,6 @@ describe(test.label, function () {
         {{frost-date-picker
           hook=myHook
           onChange=onChange
-          value=dateValue
         }}
       `)
 
@@ -122,6 +120,31 @@ describe(test.label, function () {
       expect($hook('myHook-input')).to.have.value('')
     })
   })
+
+  describe('when null is provided', function () {
+    beforeEach(function () {
+      this.setProperties({
+        dateValue: null,
+        myHook: 'myHook',
+        onChange: function () {}
+      })
+
+      this.render(hbs`
+        {{frost-date-picker
+          hook=myHook
+          onChange=onChange
+          value=dateValue
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should show a blank value', function () {
+      expect($hook('myHook-input')).to.have.value('')
+    })
+  })
+
 
   describe('when clicking inside the <input>', function () {
     beforeEach(function () {

--- a/tests/integration/components/frost-date-picker-test.js
+++ b/tests/integration/components/frost-date-picker-test.js
@@ -99,6 +99,30 @@ describe(test.label, function () {
     })
   })
 
+  describe('when empty string is provided', function () {
+    beforeEach(function () {
+      this.setProperties({
+        dateValue: '',
+        myHook: 'myHook',
+        onChange: function () {}
+      })
+
+      this.render(hbs`
+        {{frost-date-picker
+          hook=myHook
+          onChange=onChange
+          value=dateValue
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should show a blank value', function () {
+      expect($hook('myHook-input')).to.have.value('')
+    })
+  })
+
   describe('when clicking inside the <input>', function () {
     beforeEach(function () {
       this.setProperties({

--- a/tests/integration/components/frost-date-picker-test.js
+++ b/tests/integration/components/frost-date-picker-test.js
@@ -145,7 +145,6 @@ describe(test.label, function () {
     })
   })
 
-
   describe('when clicking inside the <input>', function () {
     beforeEach(function () {
       this.setProperties({


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Passing `null` or `''` to `frost-date-picker` will now show as empty instead of invalid
