### PR TITLE
Fix broken build from previous merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 # 7.2.7 (2017-08-11)
 * **Updated** move `coverage.js` config file to be in the correct location
 
+
 # 7.2.6 (2017-08-09)
 * **Updated** internal frost dependencies to match 2.12.3 versions
 * **Updated** `ember-cli-htmlbars-inline-precompile` to pin to version 0.3.12 until ember-cli/ember-cli-htmlbars-inline-precompile#90 is resolved. (See issue: #488)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Merge https://github.com/ciena-frost/ember-frost-date-picker/pull/76 into master due to previously-messed up build process, which was to upgrade `ember-code-snippet` to `2.0.0` to address error about not being able to import module npm:highlight.js in the demo app.