### PR TITLE
Update pikaday shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "chai-jquery": "^2.0.0",
     "ember-cli": "2.12.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
     "ember-frost-core": "^3.0.1",
-    "ember-pikaday-shim": "0.1.3"
+    "ember-pikaday-shim": "0.1.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This change is due to this error is showing up downstream after the release of version `1.7.0` of `pikday`:

```
The Broccoli Plugin: [Funnel: Funnel: compileAddon] failed with:
SyntaxError: pikaday/pikaday.js: 'import' and 'export' may only appear at the top level (1209:0)
```

# CHANGELOG
* **Updated** version of `ember-pikaday-shim` to `0.1.4`
* **Added** bower since it is no longer included by Ember CLI
