### PR TITLE
Update clockpicker-seconds css files to be placed in vendor

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,6 +1,5 @@
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
 @import 'node_modules/pikaday/scss/pikaday';
-@import 'node_modules/clockpicker-seconds/dist/jquery-clockpicker.min';
 
 @import './frost-date-picker';
 @import './frost-date-time-picker';

--- a/index.js
+++ b/index.js
@@ -29,11 +29,15 @@ module.exports = {
     this._super.included.apply(this, app)
 
     app.import(path.join('vendor', 'jquery-clockpicker.min.js'))
+    app.import(path.join('vendor', 'jquery-clockpicker.min.css'))
   },
 
   treeForVendor: function (vendorTree) {
     const packageTree = new Funnel(path.join(this.project.root, 'node_modules', 'clockpicker-seconds', 'dist'), {
-      files: ['jquery-clockpicker.min.js']
+      files: [
+        'jquery-clockpicker.min.js',
+        'jquery-clockpicker.min.css'
+      ]
     })
 
     return new MergeTrees([vendorTree, packageTree])


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** to provide the clockpicker-seconds css via the index.js hook (was getting a missing file path error in consumer of this add-on's builds when the import of the css was inside the add-on.scss file)