### PR TITLE
Add support for manual time entry in input field

### DIFF
--- a/addon/components/frost-date-time-picker.js
+++ b/addon/components/frost-date-time-picker.js
@@ -4,10 +4,12 @@
 
 import layout from '../templates/components/frost-date-time-picker'
 import computed, {readOnly} from 'ember-computed-decorators'
-import {Component} from 'ember-frost-core'
+import {Component, utils} from 'ember-frost-core'
 import {Format, setTime, validateTime} from 'ember-frost-date-picker'
 import {PropTypes} from 'ember-prop-types'
 import moment from 'moment'
+
+const {run} = Ember
 
 const DEFAULT_DATE_FORMAT = Format.date
 const DEFAULT_TIME_FORMAT = Format.time
@@ -84,6 +86,42 @@ export default Component.extend({
   // == Functions =============================================================
 
   // == DOM Events ============================================================
+
+  keyUp (e) {
+    const timePickerClass = 'frost-time-picker'
+
+    const keyCodes = [
+      utils.keyCodes.KEY_0,
+      utils.keyCodes.KEY_1,
+      utils.keyCodes.KEY_2,
+      utils.keyCodes.KEY_3,
+      utils.keyCodes.KEY_4,
+      utils.keyCodes.KEY_5,
+      utils.keyCodes.KEY_6,
+      utils.keyCodes.KEY_7,
+      utils.keyCodes.KEY_8,
+      utils.keyCodes.KEY_9,
+      utils.keyCodes.NUMPAD_0,
+      utils.keyCodes.NUMPAD_1,
+      utils.keyCodes.NUMPAD_2,
+      utils.keyCodes.NUMPAD_3,
+      utils.keyCodes.NUMPAD_4,
+      utils.keyCodes.NUMPAD_5,
+      utils.keyCodes.NUMPAD_6,
+      utils.keyCodes.NUMPAD_7,
+      utils.keyCodes.NUMPAD_8,
+      utils.keyCodes.NUMPAD_9,
+      utils.keyCodes.FORWARD_SLASH,
+      utils.keyCodes.DASH
+    ]
+
+    if (
+      e.target.parentElement.className.split(' ').includes(timePickerClass) &&
+      (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode == 186))
+    ) {
+      run.debounce(this.$(`.${timePickerClass} > input`), 'clockpicker', 'update', 700);
+    }
+  },
 
   // == Lifecycle Hooks =======================================================
 

--- a/addon/components/frost-date-time-picker.js
+++ b/addon/components/frost-date-time-picker.js
@@ -121,7 +121,7 @@ export default Component.extend({
 
     if (
       e.target.parentElement.className.split(' ').includes(timePickerClass) &&
-      (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode === 186))
+      (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode === utils.keyCodes.SEMICOLON))
     ) {
       if (testing) {
         this.$(`.${timePickerClass} > input`).clockpicker('update')

--- a/addon/components/frost-date-time-picker.js
+++ b/addon/components/frost-date-time-picker.js
@@ -2,6 +2,7 @@
  * Component definition for the frost-date-time-picker component
  */
 
+import Ember from 'ember'
 import layout from '../templates/components/frost-date-time-picker'
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component, utils} from 'ember-frost-core'
@@ -9,7 +10,7 @@ import {Format, setTime, validateTime} from 'ember-frost-date-picker'
 import {PropTypes} from 'ember-prop-types'
 import moment from 'moment'
 
-const {run} = Ember
+const {run, testing} = Ember
 
 const DEFAULT_DATE_FORMAT = Format.date
 const DEFAULT_TIME_FORMAT = Format.time
@@ -34,6 +35,7 @@ export default Component.extend({
     time: PropTypes.EmberComponent,
     timeFormat: PropTypes.string,
     value: PropTypes.string.isRequired,
+    timeDebounceInterval: PropTypes.number,
 
     // Events
     onChange: PropTypes.func.isRequired,
@@ -50,6 +52,7 @@ export default Component.extend({
       dateFormat: DEFAULT_DATE_FORMAT,
       timeFormat: DEFAULT_TIME_FORMAT,
       dateTimeFormat: DEFAULT_DATE_TIME_FORMAT,
+      timeDebounceInterval: 700,
       _selectedDateValueInvalid: false,
       _selectedTimeValueInvalid: false
     }
@@ -87,6 +90,7 @@ export default Component.extend({
 
   // == DOM Events ============================================================
 
+  /* eslint complexity: [2, 6] */
   keyUp (e) {
     const timePickerClass = 'frost-time-picker'
 
@@ -117,9 +121,13 @@ export default Component.extend({
 
     if (
       e.target.parentElement.className.split(' ').includes(timePickerClass) &&
-      (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode == 186))
+      (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode === 186))
     ) {
-      run.debounce(this.$(`.${timePickerClass} > input`), 'clockpicker', 'update', 700);
+      if (testing) {
+        this.$(`.${timePickerClass} > input`).clockpicker('update')
+      } else {
+        run.debounce(this.$(`.${timePickerClass} > input`), 'clockpicker', 'update', this.timeDebounceInterval)
+      }
     }
   },
 

--- a/addon/components/frost-time-picker.js
+++ b/addon/components/frost-time-picker.js
@@ -4,7 +4,7 @@
 
 import Ember from 'ember'
 import computed, {readOnly} from 'ember-computed-decorators'
-const {run} = Ember
+const {run, testing} = Ember
 import {Text, utils} from 'ember-frost-core'
 import {Format} from 'ember-frost-date-picker'
 import {PropTypes} from 'ember-prop-types'
@@ -26,6 +26,7 @@ export default Text.extend({
     donetext: PropTypes.string,
     format: PropTypes.string,
     placement: PropTypes.string,
+    timeDebounceInterval: PropTypes.number,
 
     // Options
     value: PropTypes.string.isRequired,
@@ -40,7 +41,8 @@ export default Text.extend({
       autoclose: false,
       donetext: 'Set',
       format: DEFAULT_TIME_FORMAT,
-      placement: 'right'
+      placement: 'right',
+      timeDebounceInterval: 700
     }
   },
 
@@ -111,18 +113,22 @@ export default Text.extend({
       utils.keyCodes.DASH
     ]
 
-    if (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode == 186)) {
-      run.debounce(this.$(), 'clockpicker', 'update', 700);
+    if (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode === 186)) {
+      if (testing) {
+        this.$().clockpicker('update')
+      } else {
+        run.debounce(this.$(), 'clockpicker', 'update', this.timeDebounceInterval)
+      }
     }
   },
 
-  onEnter() {
+  onEnter () {
     run.scheduleOnce('sync', this, function () {
       this.$().clockpicker('hide')
     })
   },
 
-  onEscape() {
+  onEscape () {
     run.scheduleOnce('sync', this, function () {
       this.$().clockpicker('hide')
     })

--- a/addon/components/frost-time-picker.js
+++ b/addon/components/frost-time-picker.js
@@ -85,12 +85,47 @@ export default Text.extend({
 
   // == DOM Events ============================================================
 
-  keyPress (e) {
-    if (e.keyCode === utils.keyCodes.ENTER) {
-      run.scheduleOnce('sync', this, function () {
-        this.$().clockpicker('hide')
-      })
+  keyUp (e) {
+    const keyCodes = [
+      utils.keyCodes.KEY_0,
+      utils.keyCodes.KEY_1,
+      utils.keyCodes.KEY_2,
+      utils.keyCodes.KEY_3,
+      utils.keyCodes.KEY_4,
+      utils.keyCodes.KEY_5,
+      utils.keyCodes.KEY_6,
+      utils.keyCodes.KEY_7,
+      utils.keyCodes.KEY_8,
+      utils.keyCodes.KEY_9,
+      utils.keyCodes.NUMPAD_0,
+      utils.keyCodes.NUMPAD_1,
+      utils.keyCodes.NUMPAD_2,
+      utils.keyCodes.NUMPAD_3,
+      utils.keyCodes.NUMPAD_4,
+      utils.keyCodes.NUMPAD_5,
+      utils.keyCodes.NUMPAD_6,
+      utils.keyCodes.NUMPAD_7,
+      utils.keyCodes.NUMPAD_8,
+      utils.keyCodes.NUMPAD_9,
+      utils.keyCodes.FORWARD_SLASH,
+      utils.keyCodes.DASH
+    ]
+
+    if (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode == 186)) {
+      run.debounce(this.$(), 'clockpicker', 'update', 700);
     }
+  },
+
+  onEnter() {
+    run.scheduleOnce('sync', this, function () {
+      this.$().clockpicker('hide')
+    })
+  },
+
+  onEscape() {
+    run.scheduleOnce('sync', this, function () {
+      this.$().clockpicker('hide')
+    })
   },
 
   // == Lifecycle Hooks =======================================================

--- a/addon/components/frost-time-picker.js
+++ b/addon/components/frost-time-picker.js
@@ -113,7 +113,7 @@ export default Text.extend({
       utils.keyCodes.DASH
     ]
 
-    if (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode === 186)) {
+    if (keyCodes.includes(e.keyCode) || (e.shiftKey && e.keyCode === utils.keyCodes.SEMICOLON)) {
       if (testing) {
         this.$().clockpicker('update')
       } else {

--- a/addon/templates/components/frost-date-time-picker.hbs
+++ b/addon/templates/components/frost-date-time-picker.hbs
@@ -33,6 +33,7 @@
     hook=(concat hookPrefix '-time-picker')
     class=(if (or _valueInvalid _selectedTimeValueInvalid) 'error')
     value=(readonly _timeValue)
+    timeDebounceInterval=timeDebounceInterval
     onChange=(action '_onTimeChange')
     format=(readonly timeFormat)
   }}

--- a/addon/templates/components/frost-range-picker.hbs
+++ b/addon/templates/components/frost-range-picker.hbs
@@ -15,6 +15,7 @@
     {{frost-date-time-picker
       hook='demo-date-time-picker'
       class=(if _valueInvalid 'error')
+      timeDebounceInterval=timeDebounceInterval
       value=value.start
       onChange=(action '_onStartChange')
     }}
@@ -38,6 +39,7 @@
     {{frost-date-time-picker
       hook=(concat hookPrefix '-end')
       class=(if _valueInvalid 'error')
+      timeDebounceInterval=timeDebounceInterval
       value=value.end
       onChange=(action '_onEndChange')
     }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3479,6 +3479,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3651,7 +3652,7 @@
       }
     },
     "clockpicker-seconds": {
-      "version": "git://github.com/srowhani/clockpicker-seconds.git#c1fc13ac30f7982822da0ea5736ecc01a62eb680"
+      "version": "git://github.com/srowhani/clockpicker-seconds.git#3c6d35868a0e180d75fc8c3e506ca3cbf3b9f7f7"
     },
     "clone": {
       "version": "2.1.1",
@@ -5445,6 +5446,7 @@
             "capture-exit": "1.2.0",
             "exec-sh": "0.2.1",
             "fb-watchman": "2.0.0",
+            "fsevents": "1.2.4",
             "micromatch": "3.1.10",
             "minimist": "1.2.0",
             "walker": "1.0.7",
@@ -9420,6 +9422,535 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
-    "clockpicker-seconds": "git://github.com/srowhani/clockpicker-seconds#c1fc13ac30f7982822da0ea5736ecc01a62eb680",
+    "clockpicker-seconds": "git://github.com/srowhani/clockpicker-seconds.git#3c6d35868a0e180d75fc8c3e506ca3cbf3b9f7f7",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
     "configPath": "tests/dummy/config"
   },
   "pr-bumper": {
-    "coverage": 82.87
+    "coverage": 78.14
   }
 }

--- a/tests/dummy/app/pods/experiments/template.hbs
+++ b/tests/dummy/app/pods/experiments/template.hbs
@@ -27,6 +27,7 @@
   hook='demo-time-picker'
   class=(if timeValueInvalid 'error')
   value=timeValue
+  timeDebounceInterval=700
   onChange=(action 'onTimeChange')
 }}
 {{! END-SNIPPET }}
@@ -41,6 +42,7 @@
   class=(if dateTimeValueInvalid 'error')
   value=dateTimeValue
   minDate=now
+  timeDebounceInterval=700
   onChange=(action 'onDateTimeChange')
 }}
 {{! END-SNIPPET }}
@@ -58,6 +60,7 @@
   isVertical=false
   startTitle='Custom startTitle'
   value=rangeValue
+  timeDebounceInterval=700
   onChange=(action 'onRangeChange')
 }}
 {{! END-SNIPPET }}
@@ -70,6 +73,7 @@
   isVertical=true
   startTitle='Custom startTitle'
   value=rangeValue
+  timeDebounceInterval=700
   onChange=(action 'onRangeChange')
 }}
 

--- a/tests/integration/components/frost-date-time-picker-test.js
+++ b/tests/integration/components/frost-date-time-picker-test.js
@@ -269,8 +269,16 @@ describe(test.label, function () {
       })
     })
 
+    it('should initially display expected hour value', function () {
+      expect(timepicker.getSelectedTime().hour).to.eql('01')
+    })
+
     it('should initially display expected minute value', function () {
       expect(timepicker.getSelectedTime().minute).to.eql('23')
+    })
+
+    it('should initially display expected second value', function () {
+      expect(timepicker.getSelectedTime().second).to.eql('45')
     })
 
     describe('when enter new time', function () {

--- a/tests/integration/components/frost-date-time-picker-test.js
+++ b/tests/integration/components/frost-date-time-picker-test.js
@@ -3,8 +3,11 @@
  */
 
 import {expect} from 'chai'
+import Ember from 'ember'
+import {utils} from 'ember-frost-core'
 import {Format} from 'ember-frost-date-picker'
 import {openDatepicker} from 'ember-frost-date-picker/test-support/frost-date-picker'
+import {openTimepicker} from 'ember-frost-date-picker/test-support/frost-time-picker'
 import {$hook, initialize as initializeHook} from 'ember-hook'
 import wait from 'ember-test-helpers/wait'
 import {registerMockComponent, unregisterMockComponent} from 'ember-test-utils/test-support/mock-component'
@@ -13,6 +16,8 @@ import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import moment from 'moment'
 import sinon from 'sinon'
+
+const {$} = Ember
 
 const test = integration('frost-date-time-picker')
 describe(test.label, function () {
@@ -235,6 +240,62 @@ describe(test.label, function () {
 
     it('should have selected time passed to onChange using provided dateTimeFormat', function () {
       expect(changeStub).to.have.been.calledWith('01/24/17 :: 01-23-45')
+    })
+  })
+
+  describe('enter new time in input field', function () {
+    let changeStub
+    let timepicker
+    beforeEach(function () {
+      changeStub = sandbox.stub()
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue: '01-23-45',
+        timeFormat: 'HH-mm-ss',
+        onChange: changeStub
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          value=timeValue
+          format=timeFormat
+          onChange=onChange
+        }}
+      `)
+
+      return wait().then(() => {
+        timepicker = openTimepicker('myHook')
+      })
+    })
+
+    it('should initially display expected minute value', function () {
+      expect(timepicker.getSelectedTime().minute).to.eql('23')
+    })
+
+    describe('when enter new time', function () {
+      const hour = '05'
+      const minute = '22'
+      const seconds = '15'
+
+      beforeEach(function () {
+        return wait().then(() => {
+          $hook('myHook-input').val(`${hour}:${minute}:${seconds}`)
+          $hook('myHook-input').trigger($.Event('keyup', {keyCode: utils.keyCodes.KEY_0}))
+        })
+      })
+
+      it('should display updated hour value', function () {
+        expect(timepicker.getSelectedTime().hour).to.eql(hour)
+      })
+
+      it('should display updated minute value', function () {
+        expect(timepicker.getSelectedTime().minute).to.eql(minute)
+      })
+
+      it('should display updated second value', function () {
+        expect(timepicker.getSelectedTime().second).to.eql(seconds)
+      })
     })
   })
 })

--- a/tests/integration/components/frost-time-picker-test.js
+++ b/tests/integration/components/frost-time-picker-test.js
@@ -262,8 +262,16 @@ describe(test.label, function () {
       })
     })
 
+    it('should initially display expected hour value', function () {
+      expect(timepicker.getSelectedTime().hour).to.eql('01')
+    })
+
     it('should initially display expected minute value', function () {
       expect(timepicker.getSelectedTime().minute).to.eql('23')
+    })
+
+    it('should initially display expected second value', function () {
+      expect(timepicker.getSelectedTime().second).to.eql('45')
     })
 
     describe('when enter new time', function () {

--- a/tests/integration/components/frost-time-picker-test.js
+++ b/tests/integration/components/frost-time-picker-test.js
@@ -3,6 +3,8 @@
  */
 
 import {expect} from 'chai'
+import Ember from 'ember'
+import {utils} from 'ember-frost-core'
 import {Format} from 'ember-frost-date-picker'
 import {openTimepicker} from 'ember-frost-date-picker/test-support/frost-time-picker'
 import {$hook, initialize as initializeHook} from 'ember-hook'
@@ -12,6 +14,8 @@ import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import moment from 'moment'
 import sinon from 'sinon'
+
+const {$} = Ember
 
 const test = integration('frost-time-picker')
 describe(test.label, function () {
@@ -229,6 +233,62 @@ describe(test.label, function () {
 
     it('should have onChange method called with formatted time string', function () {
       expect(changeStub).to.have.been.calledWith('05-10-15')
+    })
+  })
+
+  describe('enter new time in input field', function () {
+    let changeStub
+    let timepicker
+    beforeEach(function () {
+      changeStub = sandbox.stub()
+      this.setProperties({
+        myHook: 'myHook',
+        timeValue: '01-23-45',
+        timeFormat: 'HH-mm-ss',
+        onChange: changeStub
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          value=timeValue
+          format=timeFormat
+          onChange=onChange
+        }}
+      `)
+
+      return wait().then(() => {
+        timepicker = openTimepicker('myHook')
+      })
+    })
+
+    it('should initially display expected minute value', function () {
+      expect(timepicker.getSelectedTime().minute).to.eql('23')
+    })
+
+    describe('when enter new time', function () {
+      const hour = '05'
+      const minute = '22'
+      const seconds = '15'
+
+      beforeEach(function () {
+        return wait().then(() => {
+          $hook('myHook-input').val(`${hour}:${minute}:${seconds}`)
+          $hook('myHook-input').trigger($.Event('keyup', {keyCode: utils.keyCodes.KEY_0}))
+        })
+      })
+
+      it('should display updated hour value', function () {
+        expect(timepicker.getSelectedTime().hour).to.eql(hour)
+      })
+
+      it('should display updated minute value', function () {
+        expect(timepicker.getSelectedTime().minute).to.eql(minute)
+      })
+
+      it('should display updated second value', function () {
+        expect(timepicker.getSelectedTime().second).to.eql(seconds)
+      })
     })
   })
 


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
Yes

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
https://agile-jira.ciena.com/browse/BPSO-74078

## Screenshots or recordings
n/a

## Checklist
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [x] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* Support manual time entry in input field
  * Debounce interval for entry is configurable property
* Bugfix: now close clock picker UI when ESC key is pressed