### PR TITLE
Allow empty values

### DIFF
--- a/addon/components/frost-date-time-picker.js
+++ b/addon/components/frost-date-time-picker.js
@@ -10,7 +10,7 @@ import {Format, setTime, validateTime} from 'ember-frost-date-picker'
 import {PropTypes} from 'ember-prop-types'
 import moment from 'moment'
 
-const {run, testing} = Ember
+const {isEmpty, run, testing} = Ember
 
 const DEFAULT_DATE_FORMAT = Format.date
 const DEFAULT_TIME_FORMAT = Format.time
@@ -34,7 +34,7 @@ export default Component.extend({
     minDate: PropTypes.date,
     time: PropTypes.EmberComponent,
     timeFormat: PropTypes.string,
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
     timeDebounceInterval: PropTypes.number,
 
     // Events
@@ -63,6 +63,9 @@ export default Component.extend({
   @readOnly
   @computed('value')
   _dateValue (value) {
+    if (isEmpty(value)) {
+      return undefined
+    }
     const momentValue = moment(value)
     if (momentValue.isValid()) {
       return momentValue.format(this.get('dateFormat'))
@@ -73,6 +76,9 @@ export default Component.extend({
   @readOnly
   @computed('value')
   _timeValue (value) {
+    if (isEmpty(value)) {
+      return undefined
+    }
     const momentValue = moment(value)
     if (momentValue.isValid()) {
       return momentValue.format(this.get('timeFormat'))

--- a/addon/components/frost-range-picker.js
+++ b/addon/components/frost-range-picker.js
@@ -27,9 +27,9 @@ export default Component.extend({
     start: PropTypes.EmberComponent,
     startTitle: PropTypes.string,
     value: PropTypes.shape({
-      end: PropTypes.string.isRequired,
-      start: PropTypes.string.isRequired
-    }).isRequired,
+      end: PropTypes.string,
+      start: PropTypes.string
+    }),
 
     // Events
     onChange: PropTypes.func.isRequired,

--- a/addon/components/frost-time-picker.js
+++ b/addon/components/frost-time-picker.js
@@ -4,12 +4,12 @@
 
 import Ember from 'ember'
 import computed, {readOnly} from 'ember-computed-decorators'
-const {run, testing} = Ember
 import {Text, utils} from 'ember-frost-core'
 import {Format} from 'ember-frost-date-picker'
 import {PropTypes} from 'ember-prop-types'
 import moment from 'moment'
 
+const {isEmpty, run, testing} = Ember
 const DEFAULT_TIME_FORMAT = Format.time
 
 export default Text.extend({
@@ -29,7 +29,7 @@ export default Text.extend({
     timeDebounceInterval: PropTypes.number,
 
     // Options
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
 
     // Events
     onChange: PropTypes.func.isRequired
@@ -51,6 +51,9 @@ export default Text.extend({
   @readOnly
   @computed('value')
   _value (value) {
+    if (isEmpty(value)) {
+      return undefined
+    }
     const momentValue = moment(value, this.get('format'))
     if (momentValue.isValid()) {
       return momentValue.format(this.get('format'))

--- a/tests/dummy/app/pods/experiments/template.hbs
+++ b/tests/dummy/app/pods/experiments/template.hbs
@@ -22,7 +22,9 @@
 </div>
 
 <h3>frost-time-picker</h3>
+<h5>with a time value</h5>
 {{! BEGIN-SNIPPET time-picker-example }}
+{{! value may be undefined }}
 {{frost-time-picker
   hook='demo-time-picker'
   class=(if timeValueInvalid 'error')
@@ -31,6 +33,13 @@
   onChange=(action 'onTimeChange')
 }}
 {{! END-SNIPPET }}
+<h5>with an undefined value</h5>
+{{frost-time-picker
+  hook='demo-time-picker'
+  class=(if timeValueInvalid 'error')
+  timeDebounceInterval=700
+  onChange=(action 'onTimeChange')
+}}
 <div>
   {{code-snippet name="time-picker-example.hbs"}}
 </div>

--- a/tests/dummy/app/pods/experiments/template.hbs
+++ b/tests/dummy/app/pods/experiments/template.hbs
@@ -45,7 +45,9 @@
 </div>
 
 <h3>frost-date-time-picker</h3>
+<h5>with a datetime value</h5>
 {{! BEGIN-SNIPPET date-time-picker-example }}
+{{! value may be undefined}}
 {{frost-date-time-picker
   hook='demo-date-time-picker'
   class=(if dateTimeValueInvalid 'error')
@@ -55,6 +57,14 @@
   onChange=(action 'onDateTimeChange')
 }}
 {{! END-SNIPPET }}
+<h5>with an undefined value</h5>
+{{frost-date-time-picker
+  hook='demo-date-time-picker-undefined'
+  class=(if dateTimeValueInvalid 'error')
+  minDate=now
+  timeDebounceInterval=700
+  onChange=(action 'onDateTimeChange')
+}}
 <div>
   {{code-snippet name="date-time-picker-example.hbs"}}
 </div>

--- a/tests/integration/components/frost-date-time-picker-test.js
+++ b/tests/integration/components/frost-date-time-picker-test.js
@@ -133,7 +133,6 @@ describe(test.label, function () {
     beforeEach(function () {
       this.setProperties({
         myHook: 'myHook',
-        dateTimeValue: undefined,
         onChange: function () {}
       })
 
@@ -141,17 +140,18 @@ describe(test.label, function () {
         {{frost-date-time-picker
           hook=myHook
           onChange=onChange
-          value=dateTimeValue
         }}
       `)
+
+      return wait()
     })
 
     it('should show a blank date value', function () {
-      expect($hook('myHook-date-picker')).to.have.value('')
+      expect($hook('myHook-date-picker-input')).to.have.value('')
     })
 
     it('should show a blank time value', function () {
-      expect($hook('myHook-time-picker')).to.have.value('')
+      expect($hook('myHook-time-picker-input')).to.have.value('')
     })
   })
 

--- a/tests/integration/components/frost-date-time-picker-test.js
+++ b/tests/integration/components/frost-date-time-picker-test.js
@@ -129,6 +129,32 @@ describe(test.label, function () {
     })
   })
 
+  describe('when no value is provided', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        dateTimeValue: undefined,
+        onChange: function () {}
+      })
+
+      this.render(hbs`
+        {{frost-date-time-picker
+          hook=myHook
+          onChange=onChange
+          value=dateTimeValue
+        }}
+      `)
+    })
+
+    it('should show a blank date value', function () {
+      expect($hook('myHook-date-picker')).to.have.value('')
+    })
+
+    it('should show a blank time value', function () {
+      expect($hook('myHook-time-picker')).to.have.value('')
+    })
+  })
+
   describe('value is invalid', function () {
     beforeEach(function () {
       this.setProperties({

--- a/tests/integration/components/frost-time-picker-test.js
+++ b/tests/integration/components/frost-time-picker-test.js
@@ -61,15 +61,13 @@ describe(test.label, function () {
     beforeEach(function () {
       this.setProperties({
         myHook: 'myHook',
-        onChange: function () {},
-        value: undefined
+        onChange: function () {}
       })
 
       this.render(hbs`
         {{frost-time-picker
           hook=myHook
           onChange=onChange
-          value=value
         }}
       `)
 

--- a/tests/integration/components/frost-time-picker-test.js
+++ b/tests/integration/components/frost-time-picker-test.js
@@ -57,6 +57,54 @@ describe(test.label, function () {
     })
   })
 
+  describe('when no value is provided', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        onChange: function () {},
+        value: undefined
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=value
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should show a blank value', function () {
+      expect($hook('myHook-input')).to.have.value('')
+    })
+  })
+
+  describe('when empty string is provided', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myHook',
+        onChange: function () {},
+        value: ''
+      })
+
+      this.render(hbs`
+        {{frost-time-picker
+          hook=myHook
+          onChange=onChange
+          value=value
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should show a blank value', function () {
+      expect($hook('myHook-input')).to.have.value('')
+    })
+  })
+
   describe('format is set', function () {
     beforeEach(function () {
       this.setProperties({


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
Yes this PR closes issue #98 

## Summary
The frost-date-time-picker component did not allow empty values, so even if the UI showed a clear button which the user could click to clear the field, it could not be cleared. 

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #98 

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

## Checklist
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [x] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* Allow empty values in the frost-time-picker, frost-date-time-picker, and frost-range-picker components
